### PR TITLE
fix conditional FlashSelfAttention

### DIFF
--- a/model/115B/modeling_telechat.py
+++ b/model/115B/modeling_telechat.py
@@ -69,7 +69,6 @@ try:
 except ImportError:
     rearrange = None
 
-use_flash_attn = True
 try:
     from flash_attn.flash_attn_interface import flash_attn_unpadded_func
 except ImportError:
@@ -361,9 +360,10 @@ class TelechatAttention(nn.Module):
         self.attention_dropout = nn.Dropout(config.attention_dropout)
         self.rotary_emb = RotaryEmbedding(self.head_dim, config=config)
 
-        self.core_attention_flash = FlashSelfAttention(
-            causal=True, attention_dropout=config.attention_dropout
-        )
+        if config.flash_attn:
+            self.core_attention_flash = FlashSelfAttention(
+                causal=True, attention_dropout=config.attention_dropout
+            )
 
         self.last_key_layer = None
         # logn_list = [math.log(i, 4096) if i > 4096 else 1 for i in range(1, 32768)]


### PR DESCRIPTION
` config.json `文件的` "flash_attn":true ` 项不能控制是否使用flash_attn，故加上` if config.flash_attn: `作为判断。

` use_flash_attn = True `项是无效的，故删去。

这个问题在所有的` modeling_telechat.py `中都出现了，望修改。